### PR TITLE
feat: mainClass Extension

### DIFF
--- a/prezmanifest/loader.py
+++ b/prezmanifest/loader.py
@@ -24,7 +24,7 @@ from kurra.db import upload
 from kurra.file import make_dataset, export_quads
 from kurra.utils import load_graph
 from rdflib import DCAT, DCTERMS, OWL, PROF, RDF, SDO, SKOS
-from rdflib import Graph, URIRef, Dataset
+from rdflib import Graph, URIRef, Dataset, Namespace
 
 try:
     from prezmanifest import MRR, OLIS, validate, __version__
@@ -212,15 +212,11 @@ def load(
                             if str(f.name).endswith(".ttl"):
                                 fg = Graph().parse(f)
                                 # fg.bind("rdf", RDF)
-
+                                resource_iri = None
                                 if role == MRR.ResourceData:
-                                    resource_iri = fg.value(
-                                        predicate=RDF.type, object=SKOS.ConceptScheme
-                                    ) or fg.value(
-                                        predicate=RDF.type, object=OWL.Ontology
-                                    ) or fg.value(
-                                        predicate=RDF.type, object=SDO.CreativeWork
-                                    )
+                                    PM = Namespace("https://prez.dev/manifest-ontology/")
+                                    main_class = manifest_graph.value(subject=o, predicate=PM['mainClass'], default=SDO.CreativeWork)
+                                    resource_iri = fg.value(predicate=RDF.type, object=main_class)
 
                                 if role in [
                                     MRR.CompleteCatalogueAndResourceLabels,

--- a/prezmanifest/pm.ttl
+++ b/prezmanifest/pm.ttl
@@ -1,0 +1,23 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX pm: <https://prez.dev/manifest-ontology/>
+PREFIX prof1: <http://www.w3.org/ns/dx/prof>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+<https://prez.dev/manifest-ontology>
+    a owl:Ontology ;
+    rdfs:label "Prez Manifest" ;
+    rdfs:comment "The Prez Manifest, provides a machine readable method of describing resources intended for use in the Prez system. This Ontology is a Work In Progress." ;
+    rdfs:seeAlso "https://prez.dev/manifest" ;
+    owl:versionIRI "0.0.1" ;
+    owl:versionInfo "Initial release of the Prez Manifest owl ontology" ;
+.
+
+pm:mainClass
+    a owl:ObjectProperty ;
+    rdfs:label "Main class" ;
+    rdfs:comment "Denotes the main class of thing for a prof:ResourceDescriptor. Defaults to schema:CreativeWork if not defined." ;
+    rdfs:domain prof1:ResourceDescriptor ;
+    rdfs:range rdfs:Class ;
+    skos:usageNote "The IRI of the first resource of type pm:mainClass, in the graph of the ResourceDescriptor artifacts will be used as the identifier of a named graph, to which the data will be loaded. " ;
+.

--- a/prezmanifest/pm.ttl
+++ b/prezmanifest/pm.ttl
@@ -16,8 +16,8 @@ PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 pm:mainClass
     a owl:ObjectProperty ;
     rdfs:label "Main class" ;
-    rdfs:comment "Denotes the main class of thing for a prof:ResourceDescriptor. Defaults to schema:CreativeWork if not defined." ;
+    rdfs:comment "Denotes the main class of thing in a prof:Artifact. Defaults to schema:CreativeWork if not defined." ;
     rdfs:domain prof1:ResourceDescriptor ;
     rdfs:range rdfs:Class ;
-    skos:usageNote "The IRI of the first resource of type pm:mainClass, in the graph of the ResourceDescriptor artifacts will be used as the identifier of a named graph, to which the data will be loaded. " ;
+    skos:usageNote "For each artifact in a prof:ResourceDescriptor, the IRI of the first instance of pm:mainClass will be used as the graph name for data loading of that artifact" ;
 .

--- a/prezmanifest/validator.ttl
+++ b/prezmanifest/validator.ttl
@@ -1,4 +1,5 @@
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX pm: <https://prez.dev/manifest-ontology/>
 PREFIX prez: <https://prez.dev/>
 PREFIX prof: <http://www.w3.org/ns/dx/prof/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -8,7 +9,7 @@ PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX val: <https://prez.dev/manifest-validator/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<https://prez.dev/manifest-validator>
+prez:manifest-validator
     a owl:Ontology ;
     owl:versionIRI val:1.0.0 ;
     owl:versionInfo "1.0.0: First public version" ;
@@ -32,15 +33,40 @@ val:ShapeN02
         val:ShapeP02 ,
         val:ShapeP03 ,
         val:ShapeP04 ,
-        val:ShapeP05 ;
+        val:ShapeP05 ,
+        val:ShapeP06 ;
     sh:targetObjectsOf prof:hasResource ;
+.
+
+val:ShapeN03
+    a sh:NodeShape ;
+    sh:property
+        [
+            a sh:PropertyShape ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:path skos:inScheme ;
+        ] ;
+    sh:targetObjectsOf prof:hasRole ;
+.
+
+<https://orcid.org/0000-0002-8742-7730>
+    a schema:Person ;
+    schema:email "nick@kurrawong.ai"^^xsd:anyURI ;
+    schema:identifier "https://orcid.org/0000-0002-8742-7730"^^xsd:anyURI ;
+    schema:memberOf <https://kurrawong.ai> ;
+    schema:name "Nicholas J. Car" ;
+.
+
+val:1.0.0
+    schema:name "1.0.0" ;
 .
 
 val:ShapeP01
     a sh:PropertyShape ;
-    sh:nodeKind sh:BlankNodeOrIRI ;
     sh:message "ShapeP01: You must supply at least one value for prof:hasResource for a prez:Manifest and it must be either a Blank Node or an IRI" ;
     sh:minCount 1 ;
+    sh:nodeKind sh:BlankNodeOrIRI ;
     sh:path prof:hasResource ;
 .
 
@@ -67,11 +93,11 @@ val:ShapeP04
     sh:maxCount 1 ;
     sh:message "ShapeP04: If you supply a schema:description for a prez:Manifest's Resource Descriptors, it must be either a plain string or a langString literal" ;
     sh:or (
-
+        
         [
             sh:datatype xsd:string ;
         ]
-
+        
         [
             sh:datatype rdf:langString ;
         ]
@@ -84,11 +110,11 @@ val:ShapeP05
     sh:maxCount 1 ;
     sh:message "ShapeP05: If you supply a schema:name for a prez:Manifest's Resource Descriptors, it must be either a plain string or a langString literal" ;
     sh:or (
-
+        
         [
             sh:datatype xsd:string ;
         ]
-
+        
         [
             sh:datatype rdf:langString ;
         ]
@@ -96,27 +122,11 @@ val:ShapeP05
     sh:path schema:name ;
 .
 
-val:ShapeN03
-    a sh:NodeShape ;
-    sh:targetObjectsOf prof:hasRole ;
-    sh:property [
-        a sh:PropertyShape ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
-        sh:path skos:inScheme ;
-    ] ;
-.
-
-val:1.0.0
-    schema:name "1.0.0" ;
-.
-
-<https://orcid.org/0000-0002-8742-7730>
-    a schema:Person ;
-    schema:email "nick@kurrawong.ai"^^xsd:anyURI ;
-    schema:identifier "https://orcid.org/0000-0002-8742-7730"^^xsd:anyURI ;
-    schema:memberOf <https://kurrawong.ai> ;
-    schema:name "Nicholas J. Car" ;
+val:ShapeP06
+    a sh:PropertyShape ;
+    sh:maxCount 1 ;
+    sh:message "ShapeP06: Only one main class property is allowed per Resource Descriptor." ;
+    sh:path pm:mainClass ;
 .
 
 <https://kurrawong.ai>

--- a/tests/demo-vocabs/cw-catalog.ttl
+++ b/tests/demo-vocabs/cw-catalog.ttl
@@ -1,0 +1,11 @@
+PREFIX ex: <https://example.com/>
+PREFIX schema: <https://schema.org/>
+
+ex:cw-catalog
+    a schema:DataCatalog ;
+    schema:description "A testing catalogue for the Prez Manifest Loader tool" ;
+    schema:hasPart
+        ex:a ,
+        ex:b ;
+    schema:name "Creative Work Catalog" ;
+.

--- a/tests/demo-vocabs/cw-manifest-default.ttl
+++ b/tests/demo-vocabs/cw-manifest-default.ttl
@@ -1,0 +1,20 @@
+PREFIX mrr: <https://prez.dev/ManifestResourceRoles/>
+PREFIX prez: <https://prez.dev/>
+PREFIX prof: <http://www.w3.org/ns/dx/prof/>
+PREFIX schema: <https://schema.org/>
+
+[]    a prez:Manifest ;
+    prof:hasResource
+        [
+            prof:hasArtifact "cw-catalog.ttl" ;
+            prof:hasRole mrr:CatalogueData ;
+            schema:description "Creative Works catalog definition" ;
+            schema:name "Catalogue Definition" ;
+        ] ,
+        [
+            prof:hasArtifact "cw-resources.ttl" ;
+            prof:hasRole mrr:ResourceData ;
+            schema:description "schema:CreativeWork resources" ;
+            schema:name "Resource Data" ;
+        ] ; ;
+.

--- a/tests/demo-vocabs/cw-manifest-invalid.ttl
+++ b/tests/demo-vocabs/cw-manifest-invalid.ttl
@@ -1,0 +1,22 @@
+PREFIX mrr: <https://prez.dev/ManifestResourceRoles/>
+PREFIX pm: <https://prez.dev/manifest-ontology/>
+PREFIX prez: <https://prez.dev/>
+PREFIX prof: <http://www.w3.org/ns/dx/prof/>
+PREFIX schema: <https://schema.org/>
+
+[]    a prez:Manifest ;
+    prof:hasResource
+        [
+            prof:hasArtifact "cw-catalog.ttl" ;
+            prof:hasRole mrr:CatalogueData ;
+            schema:description "Creative Works catalog definition" ;
+            schema:name "Catalogue Definition" ;
+        ] ,
+        [
+            prof:hasArtifact "cw-resources.ttl" ;
+            prof:hasRole mrr:ResourceData ;
+            pm:mainClass schema:Person ;
+            schema:description "schema:CreativeWork resources" ;
+            schema:name "Resource Data" ;
+        ] ; ;
+.

--- a/tests/demo-vocabs/cw-manifest.ttl
+++ b/tests/demo-vocabs/cw-manifest.ttl
@@ -1,0 +1,22 @@
+PREFIX mrr: <https://prez.dev/ManifestResourceRoles/>
+PREFIX pm: <https://prez.dev/manifest-ontology/>
+PREFIX prez: <https://prez.dev/>
+PREFIX prof: <http://www.w3.org/ns/dx/prof/>
+PREFIX schema: <https://schema.org/>
+
+[]    a prez:Manifest ;
+    prof:hasResource
+        [
+            prof:hasArtifact "cw-catalog.ttl" ;
+            prof:hasRole mrr:CatalogueData ;
+            schema:description "Creative Works catalog definition" ;
+            schema:name "Catalogue Definition" ;
+        ] ,
+        [
+            prof:hasArtifact "cw-resources.ttl" ;
+            prof:hasRole mrr:ResourceData ;
+            pm:mainClass schema:CreativeWork ;
+            schema:description "schema:CreativeWork resources" ;
+            schema:name "Resource Data" ;
+        ] ; ;
+.

--- a/tests/demo-vocabs/cw-resources.ttl
+++ b/tests/demo-vocabs/cw-resources.ttl
@@ -1,0 +1,12 @@
+PREFIX ex: <https://example.com/>
+PREFIX schema: <https://schema.org/>
+
+ex:a
+    a schema:CreativeWork ;
+    schema:headline "Creative Work A" ;
+.
+
+ex:b
+    a schema:CreativeWork ;
+    schema:headline "Creative Work B" ;
+.

--- a/tests/demo-vocabs/manifest-invalid-04.ttl
+++ b/tests/demo-vocabs/manifest-invalid-04.ttl
@@ -1,0 +1,24 @@
+PREFIX mrr: <https://prez.dev/ManifestResourceRoles/>
+PREFIX pm: <https://prez.dev/manifest-ontology/>
+PREFIX prez: <https://prez.dev/>
+PREFIX prof: <http://www.w3.org/ns/dx/prof/>
+PREFIX schema: <https://schema.org/>
+
+[]    a prez:Manifest ;
+    prof:hasResource
+        [
+            prof:hasArtifact "cw-catalog.ttl" ;
+            prof:hasRole mrr:CatalogueData ;
+            schema:description "Creative Works catalog definition" ;
+            schema:name "Catalogue Definition" ;
+        ] ,
+        [
+            prof:hasArtifact "cw-resources.ttl" ;
+            prof:hasRole mrr:ResourceData ;
+            pm:mainClass
+                schema:CreativeWork ,
+                schema:Person ;
+            schema:description "schema:CreativeWork resources" ;
+            schema:name "Resource Data" ;
+        ] ; ;
+.

--- a/tests/demo-vocabs/manifest-no-labels.ttl
+++ b/tests/demo-vocabs/manifest-no-labels.ttl
@@ -1,7 +1,9 @@
 PREFIX mrr: <https://prez.dev/ManifestResourceRoles/>
+PREFIX pm: <https://prez.dev/manifest-ontology/>
 PREFIX prez: <https://prez.dev/>
 PREFIX prof: <http://www.w3.org/ns/dx/prof/>
 PREFIX schema: <https://schema.org/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
 []    a prez:Manifest ;
     prof:hasResource
@@ -14,6 +16,7 @@ PREFIX schema: <https://schema.org/>
         [
             prof:hasArtifact "vocabs/*.ttl" ;
             prof:hasRole mrr:ResourceData ;
+            pm:mainClass skos:ConceptScheme ;
             schema:description "skos:ConceptScheme objects in RDF (Turtle) files in the vocabs/ folder" ;
             schema:name "Resource Data" ;
         ] ,

--- a/tests/demo-vocabs/manifest.ttl
+++ b/tests/demo-vocabs/manifest.ttl
@@ -1,7 +1,9 @@
 PREFIX mrr: <https://prez.dev/ManifestResourceRoles/>
 PREFIX prez: <https://prez.dev/>
 PREFIX prof: <http://www.w3.org/ns/dx/prof/>
+PREFIX pm: <https://prez.dev/manifest-ontology/>
 PREFIX schema: <https://schema.org/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
 []
     a prez:Manifest ;
@@ -15,6 +17,7 @@ PREFIX schema: <https://schema.org/>
         [
             prof:hasArtifact "vocabs/*.ttl" ;
             prof:hasRole mrr:ResourceData ;
+            pm:mainClass skos:ConceptScheme ;
             schema:description "skos:ConceptScheme objects in RDF (Turtle) files in the vocabs/ folder" ;
             schema:name "Resource Data"
         ] ,

--- a/tests/test_labeller.py
+++ b/tests/test_labeller.py
@@ -149,9 +149,11 @@ def test_label_manifest(fuseki_container):
     expected_updated_manifest = Graph().parse(
         data="""
         PREFIX mrr: <https://prez.dev/ManifestResourceRoles/>
+        PREFIX pm: <https://prez.dev/manifest-ontology/>
         PREFIX prez: <https://prez.dev/>
         PREFIX prof: <http://www.w3.org/ns/dx/prof/>
         PREFIX schema: <https://schema.org/>
+        PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
         
         []    a prez:Manifest ;
             prof:hasResource
@@ -168,6 +170,7 @@ def test_label_manifest(fuseki_container):
                 [
                     prof:hasArtifact "vocabs/*.ttl" ;
                     prof:hasRole mrr:ResourceData ;
+                    pm:mainClass skos:ConceptScheme ;
                     schema:description "skos:ConceptScheme objects in RDF (Turtle) files in the vocabs/ folder" ;
                     schema:name "Resource Data" ;
                 ] ,
@@ -183,9 +186,10 @@ def test_label_manifest(fuseki_container):
 
     resulting_manifest = Graph().parse(original_manifest_path)
 
-    assert isomorphic(resulting_manifest, expected_updated_manifest)
-
-    # replace this test's results and with original
-    Path(original_manifest_path.parent / "labels-additional.ttl").unlink()
-    original_manifest_path.unlink()
-    original_manifest_path.write_text(original_manifest_contents)
+    try:
+        assert isomorphic(resulting_manifest, expected_updated_manifest)
+    finally:
+        # replace this test's results with original
+        Path(original_manifest_path.parent / "labels-additional.ttl").unlink()
+        original_manifest_path.unlink()
+        original_manifest_path.write_text(original_manifest_contents)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -47,8 +47,8 @@ def test_load_only_one_set():
         load(manifest_path, return_data_type="hello")
     except ValueError as e:
         assert (
-            str(e)
-            == "return_data_type was set to an invalid value. Must be one of Dataset or Graph or None"
+                str(e)
+                == "return_data_type was set to an invalid value. Must be one of Dataset or Graph or None"
         )
 
 
@@ -176,3 +176,36 @@ def test_load_to_fuseki_basic_auth(fuseki_container):
     count = int(r[0]["count"]["value"])
 
     assert count == 5
+
+
+def test_mainclass(fuseki_container):
+    sparql_endpoint = (
+        f"http://localhost:{fuseki_container.get_exposed_port(3030)}/ds"
+    )
+    manifest = Path(__file__).parent / "demo-vocabs" / "cw-manifest.ttl"
+    load(manifest=manifest, sparql_endpoint=sparql_endpoint)
+    query = "SELECT DISTINCT ?g WHERE { GRAPH ?g { } }"
+    result = sparql(sparql_endpoint=sparql_endpoint, query=query, return_python=True)
+    named_graphs = [r['g']['value'] for r in result['results']['bindings']]
+    assert "https://example.com/a" in named_graphs
+
+
+def test_mainclass_default(fuseki_container):
+    sparql_endpoint = (
+        f"http://localhost:{fuseki_container.get_exposed_port(3030)}/ds"
+    )
+    manifest = Path(__file__).parent / "demo-vocabs" / "cw-manifest-default.ttl"
+    load(manifest=manifest, sparql_endpoint=sparql_endpoint)
+    query = "SELECT DISTINCT ?g WHERE { GRAPH ?g { } }"
+    result = sparql(sparql_endpoint=sparql_endpoint, query=query, return_python=True)
+    named_graphs = [r['g']['value'] for r in result['results']['bindings']]
+    assert "https://example.com/a" in named_graphs
+
+
+def test_mainclass_invalid(fuseki_container):
+    sparql_endpoint = (
+        f"http://localhost:{fuseki_container.get_exposed_port(3030)}/ds"
+    )
+    manifest = Path(__file__).parent / "demo-vocabs" / "cw-manifest-invalid.ttl"
+    with pytest.raises(ValueError, match="Could not determine Resource IRI"):
+        load(manifest=manifest, sparql_endpoint=sparql_endpoint)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -178,34 +178,21 @@ def test_load_to_fuseki_basic_auth(fuseki_container):
     assert count == 5
 
 
-def test_mainclass(fuseki_container):
-    sparql_endpoint = (
-        f"http://localhost:{fuseki_container.get_exposed_port(3030)}/ds"
-    )
+def test_mainclass():
     manifest = Path(__file__).parent / "demo-vocabs" / "cw-manifest.ttl"
-    load(manifest=manifest, sparql_endpoint=sparql_endpoint)
-    query = "SELECT DISTINCT ?g WHERE { GRAPH ?g { } }"
-    result = sparql(sparql_endpoint=sparql_endpoint, query=query, return_python=True)
-    named_graphs = [r['g']['value'] for r in result['results']['bindings']]
-    assert "https://example.com/a" in named_graphs
+    ds = load(manifest=manifest, return_data_type="Dataset")
+    named_graphs = [g.identifier for g in ds.graphs()]
+    assert URIRef("https://example.com/a") in named_graphs
 
 
-def test_mainclass_default(fuseki_container):
-    sparql_endpoint = (
-        f"http://localhost:{fuseki_container.get_exposed_port(3030)}/ds"
-    )
+def test_mainclass_default():
     manifest = Path(__file__).parent / "demo-vocabs" / "cw-manifest-default.ttl"
-    load(manifest=manifest, sparql_endpoint=sparql_endpoint)
-    query = "SELECT DISTINCT ?g WHERE { GRAPH ?g { } }"
-    result = sparql(sparql_endpoint=sparql_endpoint, query=query, return_python=True)
-    named_graphs = [r['g']['value'] for r in result['results']['bindings']]
-    assert "https://example.com/a" in named_graphs
+    ds = load(manifest=manifest, return_data_type="Dataset")
+    named_graphs = [g.identifier for g in ds.graphs()]
+    assert URIRef("https://example.com/a") in named_graphs
 
 
-def test_mainclass_invalid(fuseki_container):
-    sparql_endpoint = (
-        f"http://localhost:{fuseki_container.get_exposed_port(3030)}/ds"
-    )
+def test_mainclass_invalid():
     manifest = Path(__file__).parent / "demo-vocabs" / "cw-manifest-invalid.ttl"
     with pytest.raises(ValueError, match="Could not determine Resource IRI"):
-        load(manifest=manifest, sparql_endpoint=sparql_endpoint)
+        ds = load(manifest=manifest, return_data_type="Dataset")

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import pytest
 
 try:
     from prezmanifest import validate
@@ -32,6 +33,11 @@ def test_validator_invalid_02():
         validate(Path(__file__).parent / "demo-vocabs" / "manifest-invalid-03.ttl")
     except ValueError as e:
         assert (
-            str(e)
-            == "Remote content link non-resolving: https://github.com/RDFLib/prez/blob/main/prez/reference_data/profiles/ogc_records_profile.ttlx"
+                str(e)
+                == "Remote content link non-resolving: https://github.com/RDFLib/prez/blob/main/prez/reference_data/profiles/ogc_records_profile.ttlx"
         )
+
+
+def test_validator_invalid_04():
+    with pytest.raises(ValueError, match="ShapeP06"):
+        validate(Path(__file__).parent / "demo-vocabs" / "manifest-invalid-04.ttl")


### PR DESCRIPTION
Adds support for the declaration of a mainClass.

that is, a class for a resourceData instance from which a graph name should be derived.

This extension does the following:

1. declares the prezmanifest ontology as <https://prez.dev/prez/manifest-ontology> ( prefixed as pm: )
2. defines a single owl:ObjectProperty called pm:mainClass
3. implements the logic for this property,
4. adds the simple test cases for the implementation

BREAKING CHANGE